### PR TITLE
fix(github-webhook): move server init to initializer

### DIFF
--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -10,14 +10,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func initializer(sdk sdk.KaiSDK) {
-	sdk.Logger.Info("Initializing webhook")
+func initializer(kaiSDK sdk.KaiSDK) {
+	kaiSDK.Logger.Info("Initializing webhook")
 
 	wh := webhook.NewGithubWebhook()
 
-	err := wh.InitWebhook(sdk)
+	err := wh.InitWebhook(kaiSDK)
 	if err != nil {
-		sdk.Logger.Error(err, "error creating webhook")
+		kaiSDK.Logger.Error(err, "error creating webhook")
 		os.Exit(1)
 	}
 }

--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -21,8 +21,8 @@ func initializer(kaiSDK sdk.KaiSDK) {
 	}
 }
 
-func runnerFunc(tr *trigger.Runner, sdk sdk.KaiSDK) {
-	sdk.Logger.Info("Running webhook handler")
+func runnerFunc(tr *trigger.Runner, kaiSDK sdk.KaiSDK) {
+	kaiSDK.Logger.Info("Running webhook handler")
 }
 
 func main() {

--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -7,20 +7,30 @@ import (
 	"github.com/konstellation-io/kai-sdk/go-sdk/runner"
 	"github.com/konstellation-io/kai-sdk/go-sdk/runner/trigger"
 	"github.com/konstellation-io/kai-sdk/go-sdk/sdk"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func runnerFunc(wh webhook.Webhook) trigger.RunnerFunc {
-	return func(tr *trigger.Runner, sdk sdk.KaiSDK) {
-		err := wh.InitWebhook(sdk)
-		if err != nil {
-			sdk.Logger.Error(err, "error creating webhook")
-			os.Exit(1)
-		}
+func initializer(sdk sdk.KaiSDK) {
+	sdk.Logger.Info("Initializing webhook")
+
+	wh := webhook.NewGithubWebhook()
+
+	err := wh.InitWebhook(sdk)
+	if err != nil {
+		sdk.Logger.Error(err, "error creating webhook")
+		os.Exit(1)
 	}
 }
 
+func runnerFunc(tr *trigger.Runner, sdk sdk.KaiSDK) {
+	sdk.Messaging.SendOutput(&anypb.Any{})
+}
+
 func main() {
-	wh := webhook.NewGithubWebhook()
-	r := runner.NewRunner().TriggerRunner().WithRunner(runnerFunc(wh))
+	r := runner.NewRunner().
+		TriggerRunner().
+		WithInitializer(initializer).
+		WithRunner(runnerFunc)
+
 	r.Run()
 }

--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/konstellation-io/kai-sdk/go-sdk/runner"
 	"github.com/konstellation-io/kai-sdk/go-sdk/runner/trigger"
 	"github.com/konstellation-io/kai-sdk/go-sdk/sdk"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func initializer(kaiSDK sdk.KaiSDK) {
@@ -23,7 +22,7 @@ func initializer(kaiSDK sdk.KaiSDK) {
 }
 
 func runnerFunc(tr *trigger.Runner, sdk sdk.KaiSDK) {
-	sdk.Messaging.SendOutput(&anypb.Any{})
+	sdk.Logger.Info("Running webhook handler")
 }
 
 func main() {

--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -9,15 +9,15 @@ import (
 	"github.com/konstellation-io/kai-sdk/go-sdk/sdk"
 )
 
-func initializer(kaiSDK sdk.KaiSDK) {
-	kaiSDK.Logger.Info("Initializing webhook")
+func initializer(wh webhook.Webhook) func(kaiSDK sdk.KaiSDK) {
+	return func(kaiSDK sdk.KaiSDK) {
+		kaiSDK.Logger.Info("Initializing webhook")
 
-	wh := webhook.NewGithubWebhook()
-
-	err := wh.InitWebhook(kaiSDK)
-	if err != nil {
-		kaiSDK.Logger.Error(err, "error creating webhook")
-		os.Exit(1)
+		err := wh.InitWebhook(kaiSDK)
+		if err != nil {
+			kaiSDK.Logger.Error(err, "error creating webhook")
+			os.Exit(1)
+		}
 	}
 }
 
@@ -26,9 +26,11 @@ func runnerFunc(tr *trigger.Runner, kaiSDK sdk.KaiSDK) {
 }
 
 func main() {
+	wh := webhook.NewGithubWebhook()
+
 	r := runner.NewRunner().
 		TriggerRunner().
-		WithInitializer(initializer).
+		WithInitializer(initializer(wh)).
 		WithRunner(runnerFunc)
 
 	r.Run()

--- a/github-webhook-trigger/main_test.go
+++ b/github-webhook-trigger/main_test.go
@@ -34,13 +34,13 @@ func (s *MainSuite) TearDownTest() {
 	s.githubWebhookMock.ExpectedCalls = nil
 }
 
-func (s *MainSuite) TestRunnerFunc() {
+func (s *MainSuite) TestInitializer() {
 	s.githubWebhookMock.On("InitWebhook", s.kaiSdkMock).Return(nil)
 
-	runnerFunc(s.githubWebhookMock)(nil, s.kaiSdkMock)
+	initializer(s.githubWebhookMock)(s.kaiSdkMock)
 }
 
-func (s *MainSuite) TestRunnerFuncError() {
+func (s *MainSuite) TestInitializerError() {
 	s.githubWebhookMock.On("InitWebhook", s.kaiSdkMock).Return(fmt.Errorf("mocked error"))
 
 	fakeExitCalled := 0
@@ -51,5 +51,9 @@ func (s *MainSuite) TestRunnerFuncError() {
 	patch := monkey.Patch(os.Exit, fakeExit)
 	defer patch.Unpatch()
 
-	runnerFunc(s.githubWebhookMock)(nil, s.kaiSdkMock)
+	initializer(s.githubWebhookMock)(s.kaiSdkMock)
+}
+
+func (s *MainSuite) TestRunnerFunc() {
+	runnerFunc(nil, s.kaiSdkMock)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix webhook creation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is the correct use to use a kai trigger

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
