### PR TITLE
feat(github-trigger): rearrange correctly initializer and runner funcs

### DIFF
--- a/github-webhook-trigger/main.go
+++ b/github-webhook-trigger/main.go
@@ -9,9 +9,13 @@ import (
 	"github.com/konstellation-io/kai-sdk/go-sdk/sdk"
 )
 
-func initializer(wh webhook.Webhook) func(kaiSDK sdk.KaiSDK) {
-	return func(kaiSDK sdk.KaiSDK) {
-		kaiSDK.Logger.Info("Initializing webhook")
+func initializer(kaiSDK sdk.KaiSDK) {
+	kaiSDK.Logger.Info("Initializing webhook")
+}
+
+func runnerFunc(wh webhook.Webhook) func(tr *trigger.Runner, kaiSDK sdk.KaiSDK) {
+	return func(tr *trigger.Runner, kaiSDK sdk.KaiSDK) {
+		kaiSDK.Logger.Info("Running webhook handler")
 
 		err := wh.InitWebhook(kaiSDK)
 		if err != nil {
@@ -21,17 +25,13 @@ func initializer(wh webhook.Webhook) func(kaiSDK sdk.KaiSDK) {
 	}
 }
 
-func runnerFunc(tr *trigger.Runner, kaiSDK sdk.KaiSDK) {
-	kaiSDK.Logger.Info("Running webhook handler")
-}
-
 func main() {
 	wh := webhook.NewGithubWebhook()
 
 	r := runner.NewRunner().
 		TriggerRunner().
-		WithInitializer(initializer(wh)).
-		WithRunner(runnerFunc)
+		WithInitializer(initializer).
+		WithRunner(runnerFunc(wh))
 
 	r.Run()
 }

--- a/github-webhook-trigger/main_test.go
+++ b/github-webhook-trigger/main_test.go
@@ -35,12 +35,16 @@ func (s *MainSuite) TearDownTest() {
 }
 
 func (s *MainSuite) TestInitializer() {
-	s.githubWebhookMock.On("InitWebhook", s.kaiSdkMock).Return(nil)
-
-	initializer(s.githubWebhookMock)(s.kaiSdkMock)
+	initializer(s.kaiSdkMock)
 }
 
-func (s *MainSuite) TestInitializerError() {
+func (s *MainSuite) TestRunnerFunc() {
+	s.githubWebhookMock.On("InitWebhook", s.kaiSdkMock).Return(nil)
+
+	runnerFunc(s.githubWebhookMock)(nil, s.kaiSdkMock)
+}
+
+func (s *MainSuite) TestRunnerFuncError() {
 	s.githubWebhookMock.On("InitWebhook", s.kaiSdkMock).Return(fmt.Errorf("mocked error"))
 
 	fakeExitCalled := 0
@@ -51,9 +55,5 @@ func (s *MainSuite) TestInitializerError() {
 	patch := monkey.Patch(os.Exit, fakeExit)
 	defer patch.Unpatch()
 
-	initializer(s.githubWebhookMock)(s.kaiSdkMock)
-}
-
-func (s *MainSuite) TestRunnerFunc() {
-	runnerFunc(nil, s.kaiSdkMock)
+	runnerFunc(s.githubWebhookMock)(nil, s.kaiSdkMock)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Moved initilializer logic to runner

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The intended way of working for triggers in our sdk is that if we want to deploy a listener, it should be done in the runner func.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
